### PR TITLE
moudule port to 8080 change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
     build: ./org-service
     container_name: org-service
     ports:
-      - "8081:8081"
+      - "8081:8080"
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://org-db:3306/org_db
       SPRING_DATASOURCE_USERNAME: root
@@ -136,7 +136,7 @@ services:
     build: ./user-service
     container_name: user-service
     ports:
-      - "8082:8082"
+      - "8082:8080"
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://user-db:3306/user_db
       SPRING_DATASOURCE_USERNAME: root
@@ -150,7 +150,7 @@ services:
     build: ./offering-service
     container_name: offering-service
     ports:
-      - "8083:8083"
+      - "8083:8080"
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://offering-db:3306/offering_db
       SPRING_DATASOURCE_USERNAME: root
@@ -166,7 +166,7 @@ services:
     build: ./activity-service
     container_name: activity-service
     ports:
-      - "8084:8084"
+      - "8084:8080"
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://activity-db:3306/activity_db
       SPRING_DATASOURCE_USERNAME: root
@@ -182,7 +182,7 @@ services:
     build: ./prayer-service
     container_name: prayer-service
     ports:
-      - "8085:8085"
+      - "8085:8080"
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://prayer-db:3306/prayer_db
       SPRING_DATASOURCE_USERNAME: root

--- a/offering-service/src/main/resources/application.yml
+++ b/offering-service/src/main/resources/application.yml
@@ -1,6 +1,3 @@
-server:
-  port: 8083
-
 spring:
   profiles:
     active: local

--- a/org-service/src/main/resources/application.yml
+++ b/org-service/src/main/resources/application.yml
@@ -1,6 +1,3 @@
-server:
-  port: 8081
-
 spring:
   profiles:
     active: local

--- a/prayer-service/src/main/resources/application.yml
+++ b/prayer-service/src/main/resources/application.yml
@@ -1,6 +1,3 @@
-server:
-  port: 8085
-
 spring:
   profiles:
     active: local

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -1,6 +1,3 @@
-server:
-  port: 8082
-
 spring:
   profiles:
     active: local


### PR DESCRIPTION
## 📄 Description

- Close : #

> 기능에 대한 설명
docker-compose.yml 파일에서 모든 모듈 컨테이너들의 내부포트번호를 8080번으로 맞췄습니다.
각 모듈의 application.yml  기존의 포트번호를 지웠습니다 (자동으로 8080할당됨)

## 📌 구현 내용

- [ ] 구현한 기능을 적습니다 (1)
- [ ] 구현한 기능을 적습니다 (2)

## ✅ PR 포인트

없으면 생략 가능